### PR TITLE
Fix logging parameter typo

### DIFF
--- a/src/one_dragon/utils/http_utils.py
+++ b/src/one_dragon/utils/http_utils.py
@@ -53,5 +53,5 @@ def download_file(download_url: str, save_file_path: str,
         msg = f'下载失败 {e}'
         if progress_callback is not None:
             progress_callback(0, msg)
-        log.error(msg, exec=True)
+        log.error(msg, exc_info=True)
         return False


### PR DESCRIPTION
## Summary
- correct `log.error` parameter name in `http_utils.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684144d70a2c832091c03abf08e79ed3