### PR TITLE
修正 get_monday_dt 中的文本注释

### DIFF
--- a/src/one_dragon/utils/os_utils.py
+++ b/src/one_dragon/utils/os_utils.py
@@ -129,7 +129,7 @@ def get_monday_dt(dt: str) -> str:
     """
     根据一个日期，获取对应星期一的日期
     :param dt: 日期 yyyyMMdd 格式
-    :return: 星期天日期 yyyyMMdd 格式
+    :return: 星期一日期 yyyyMMdd 格式
     """
     date = datetime.datetime.strptime(dt, "%Y%m%d")
     weekday = date.weekday()  # 0表示星期一，6表示星期天


### PR DESCRIPTION
## Summary
- correct the docstring for `get_monday_dt` to state that it returns the Monday date

## Testing
- `python -m py_compile src/one_dragon/utils/os_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68414a0e18908320b599c9574e03db90