### PR TITLE
Add reconnect check

### DIFF
--- a/assets/game_data/screen_info/network_disconnect_dialog.yml
+++ b/assets/game_data/screen_info/network_disconnect_dialog.yml
@@ -1,0 +1,30 @@
+screen_id: network_disconnect_dialog
+screen_name: 断网重连弹窗
+pc_alt: false
+area_list:
+- area_name: 文本-断网提示
+  id_mark: true
+  pc_rect:
+  - 780
+  - 480
+  - 1150
+  - 550
+  text: 与服务器断开连接，请重新登录
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  goto_list: []
+- area_name: 按钮-确认
+  id_mark: false
+  pc_rect:
+  - 950
+  - 630
+  - 1020
+  - 660
+  text: 确认
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  goto_list: []

--- a/src/one_dragon/base/operation/operation.py
+++ b/src/one_dragon/base/operation/operation.py
@@ -18,6 +18,7 @@ from one_dragon.base.screen.screen_area import ScreenArea
 from one_dragon.base.screen.screen_utils import OcrClickResultEnum, FindAreaResultEnum
 from one_dragon.utils import debug_utils, cv2_utils, str_utils
 from one_dragon.utils.i18_utils import coalesce_gt, gt
+from sr_od.operations.reconnect_exception import ReconnectException
 from one_dragon.utils.log_utils import log
 
 
@@ -310,6 +311,12 @@ class Operation(OperationBase):
                         log.info('%s 节点 %s 返回状态 %s', self.display_name, node_name, round_result_status)
                 if self.ctx.is_context_pause:  # 有可能触发暂停的时候仍在执行指令 执行完成后 再次触发暂停回调 保证操作的暂停回调真正生效
                     self._on_pause()
+            except ReconnectException:
+                log.info("检测到断网异常，重新进入游戏")
+                if "打开并进入游戏" in self._node_map:
+                    self._current_node = self._node_map["打开并进入游戏"]
+                    self._reset_status_for_new_node()
+                    continue
             except Exception as e:
                 round_result: OperationRoundResult = self.round_retry('异常')
                 if self.last_screenshot is not None:

--- a/src/sr_od/operations/reconnect_exception.py
+++ b/src/sr_od/operations/reconnect_exception.py
@@ -1,0 +1,3 @@
+class ReconnectException(Exception):
+    """Raised when network disconnect dialog is detected"""
+    pass

--- a/src/sr_od/operations/sr_operation.py
+++ b/src/sr_od/operations/sr_operation.py
@@ -2,8 +2,12 @@ from typing import Optional, Callable
 
 from one_dragon.base.operation.operation import Operation
 from one_dragon.base.operation.operation_base import OperationResult
+from one_dragon.utils import cv2_utils, str_utils
+from one_dragon.base.geometry.rectangle import Rect
+from one_dragon.base.geometry.point import Point
 from sr_od.context.sr_context import SrContext
 from sr_od.operations.enter_game.open_and_enter_game import OpenAndEnterGame
+from sr_od.operations.reconnect_exception import ReconnectException
 
 
 class SrOperation(Operation):
@@ -25,3 +29,17 @@ class SrOperation(Operation):
                            op_callback=op_callback,
                            need_check_game_win=need_check_game_win,
                            op_to_enter_game=op_to_enter_game)
+
+    def screenshot(self):
+        screen = super().screenshot()
+        self._check_reconnect_dialog(screen)
+        return screen
+
+    def _check_reconnect_dialog(self, screen):
+        rect = Rect(780, 480, 1150, 550)
+        part = cv2_utils.crop_image_only(screen, rect)
+        ocr_result_map = self.ctx.ocr.run_ocr(part)
+        for text in ocr_result_map.keys():
+            if str_utils.find_by_lcs('与服务器断开连接，请重新登录', text, percent=0.6):
+                self.ctx.controller.click(Point(985, 645))
+                raise ReconnectException()


### PR DESCRIPTION
## Summary
- handle reconnect dialog globally by raising `ReconnectException`
- detect disconnect pop-up in `SrOperation.screenshot`
- jump to re-login when detected
- add screen info for network disconnect dialog

## Testing
- `python -m compileall -q src/sr_od src/one_dragon`

------
https://chatgpt.com/codex/tasks/task_e_684149cf0ab48320a2833219e9662c37